### PR TITLE
Add pgadmin to lighthouse network for container communication

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,8 @@ services:
     image: dpage/pgadmin4:latest
     container_name: pgadmin-container-lighthouse
     restart: always
+    networks:
+      - lighthouse
     ports:
       - "8081:80"
     environment:


### PR DESCRIPTION
 Added pgadmin service to the lighthouse network. This enables pgadmin to connect to postgres using the service name "postgres" as the hostname.


<img width="632" alt="image" src="https://github.com/user-attachments/assets/1a6390b7-e127-4874-9676-2e47ad9fc0d7" />


 Simplifies connection configuration and improves container networking reliability. No need to use IP addresses or localhost for container-to-container communication.